### PR TITLE
Support for `coin` and `reportedby` fields in blacklist_urls.yaml

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,12 +13,19 @@ const writeConfig = require('./utils/writeConfig');
 const app = express();
 
 module.exports.update = async () => {
-	if(config.lookups.DNS.IP.enabled || config.lookups.DNS.NS.enabled || config.lookups.HTTP.enabled) {
-		debug("Spawning update process...");
-		const updateProcess = fork(path.join(__dirname,'scripts/update.js'));
-		updateProcess.on('message', data => db.write(data.url,data));
-		updateProcess.on('exit', () => setTimeout(() => this.update(),config.interval.cacheRenewCheck));
-	}
+	/* Create and write to cache.db */
+	debug("Spawning update process...");
+	const updateProcess = fork(path.join(__dirname,'scripts/update.js'));
+	debug("Writing to cache.db")
+	updateProcess.on('message', data => db.write(data.url,data));
+
+	/* After db is initially written, write the cache.db every cacheRenewCheck-defined period */
+	updateProcess.on('exit', () => {
+		debug("UpdateProcess completed - Next run is in " + config.interval.cacheRenewCheck/1000 + " seconds.") 
+		setTimeout(() => {
+			this.update();
+		}, config.interval.cacheRenewCheck);
+	})	
 }
 
 module.exports.serve = async (electronApp) => {

--- a/src/classes/scam.class.js
+++ b/src/classes/scam.class.js
@@ -13,7 +13,7 @@ module.exports = class Scam {
 		if(scamObject.subcategory) this.subcategory = scamObject.subcategory;
 		if(scamObject.description) this.description = scamObject.description;
         if(scamObject.addresses) this.addresses = scamObject.addresses;
-        if(scamObject.reportedby) this.reportedby = scamObject.reportedby;
+        if(scamObject.reporter) this.reporter = scamObject.reporter;
         if(scamObject.coin) this.coin = scamObject.coin;
 	}
 

--- a/src/classes/scam.class.js
+++ b/src/classes/scam.class.js
@@ -12,7 +12,9 @@ module.exports = class Scam {
 		if(scamObject.category) this.category = scamObject.category;
 		if(scamObject.subcategory) this.subcategory = scamObject.subcategory;
 		if(scamObject.description) this.description = scamObject.description;
-		if(scamObject.addresses) this.addresses = scamObject.addresses;
+        if(scamObject.addresses) this.addresses = scamObject.addresses;
+        if(scamObject.reportedby) this.reportedby = scamObject.reportedby;
+        if(scamObject.coin) this.coin = scamObject.coin;
 	}
 
 	/* Returns either `false` or a request response */

--- a/src/scripts/update.js
+++ b/src/scripts/update.js
@@ -19,7 +19,7 @@ process.once('close', () => process.exit(1));	/* Close if parent process exits *
 	debug("Updating scams...");
 
 	/* Update all scams which weren't updated recently */
-	await Promise.all(serialijse.deserialize(cacheFile).scams.reverse().filter(scam => scam.howRecent() > config.interval.cacheExpiration).map(async scam => {
+	Promise.all(serialijse.deserialize(cacheFile).scams.reverse().filter(scam => scam.howRecent() > config.interval.cacheExpiration).map(async scam => {
 		if(config.lookups.HTTP.enabled) await scam.getStatus();			/* Update status */
 		if(config.lookups.DNS.IP.enabled) await scam.getIP();			/* Update IP */
 		if(config.lookups.DNS.NS.enabled) await scam.getNameservers();	/* Update nameservers */
@@ -28,13 +28,18 @@ process.once('close', () => process.exit(1));	/* Close if parent process exits *
 		process.send({
 			url: scam.url,
 			name: scam.name,
-			ip: scam.ip,
+            ip: scam.ip,
+            category: scam.category,
+			subcategory: scam.subcategory,
 			nameservers: scam.nameservers,
-			status: scam.status,
+            status: scam.status,
+            reportedby: scam.reportedby,
+            coin: scam.coin,
 			statusCode: scam.statusCode,
 			updated: Date.now()
 		});
-	}));
-
-	debug("Done updating!");
+    })).then(() => {
+		debug("Updating scams completed!")
+		process.exit(1)
+	})
 })();

--- a/src/scripts/update.js
+++ b/src/scripts/update.js
@@ -19,7 +19,7 @@ process.once('close', () => process.exit(1));	/* Close if parent process exits *
 	debug("Updating scams...");
 
 	/* Update all scams which weren't updated recently */
-	Promise.all(serialijse.deserialize(cacheFile).scams.reverse().filter(scam => scam.howRecent() > config.interval.cacheExpiration).map(async scam => {
+	await Promise.all(serialijse.deserialize(cacheFile).scams.reverse().filter(scam => scam.howRecent() > config.interval.cacheExpiration).map(async scam => {
 		if(config.lookups.HTTP.enabled) await scam.getStatus();			/* Update status */
 		if(config.lookups.DNS.IP.enabled) await scam.getIP();			/* Update IP */
 		if(config.lookups.DNS.NS.enabled) await scam.getNameservers();	/* Update nameservers */
@@ -38,8 +38,7 @@ process.once('close', () => process.exit(1));	/* Close if parent process exits *
 			statusCode: scam.statusCode,
 			updated: Date.now()
 		});
-    })).then(() => {
-		debug("Updating scams completed!")
-		process.exit(1)
-	})
+    }));
+	debug("Updating scams completed!")
+	process.exit(1)
 })();

--- a/src/scripts/update.js
+++ b/src/scripts/update.js
@@ -33,7 +33,7 @@ process.once('close', () => process.exit(1));	/* Close if parent process exits *
 			subcategory: scam.subcategory,
 			nameservers: scam.nameservers,
             status: scam.status,
-            reportedby: scam.reportedby,
+            reporter: scam.reporter,
             coin: scam.coin,
 			statusCode: scam.statusCode,
 			updated: Date.now()

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -46,7 +46,7 @@ const readEntries = async () => {
 			db.scams[index].category = entry.category;
 			db.scams[index].subcategory = entry.subcategory;
             db.scams[index].description = entry.description;
-            db.scams[index].reportedby = entry.reportedby;
+            db.scams[index].reporter = entry.reporter;
             db.scams[index].coin = entry.coin;
 		});
 		yaml.safeLoad(verifiedFile).forEach(entry => {

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -41,12 +41,26 @@ const readEntries = async () => {
 		Object.assign(db,serialijse.deserialize(cacheFile));
 		yaml.safeLoad(scamsFile).filter(entry => !db.scams.find(scam => scam.url == entry.url)).map(entry => new Scam(entry)).forEach(entry => db.scams.push(entry));
 		yaml.safeLoad(verifiedFile).filter(entry => !db.verified.find(verified => verified.url == entry.url)).forEach(entry => db.verified.push(entry));
+		yaml.safeLoad(scamsFile).forEach(entry => {
+			var index = db.scams.indexOf(db.scams.find(scam => scam.url == entry.url))
+			db.scams[index].category = entry.category;
+			db.scams[index].subcategory = entry.subcategory;
+            db.scams[index].description = entry.description;
+            db.scams[index].reportedby = entry.reportedby;
+            db.scams[index].coin = entry.coin;
+		});
+		yaml.safeLoad(verifiedFile).forEach(entry => {
+			var index = db.verified.indexOf(db.verified.find(verified => verified.url == entry.url))
+			db.verified[index].url = entry.url;
+			db.verified[index].description = entry.description;
+			if(entry.addresses) db.verified[index].addresses = entry.addresses;			
+		});
 	}
 }
 
 /* Create indexes for DB object */
 const updateIndex = async () => {
-	debug("Updating index...");
+	//debug("Updating index...");
 	const scamDictionary = createDictionary(db.scams);
 	const verifiedDictionary = createDictionary(db.verified);
 	

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -9,7 +9,7 @@ const debug = require('debug')('github');
 const pullDataFiles = async () => {
 	debug("Pulling data files...");
 	await download("https://raw.githubusercontent.com/CryptoScamDB/whitelist/master/data/urls.yaml", "data", { filename: "whitelist_urls.yaml" });
-	await download("https://raw.githubusercontent.com/CryptoScamDB/blacklist/master/data/urls.yaml", "data", { filename: "blacklist_urls.yaml" });
+	await download("https://gist.githubusercontent.com/hahnmichaelf/43eb34ebbc88d9b7bf23748469f7bf8e/raw/urls.yaml", "data", { filename: "blacklist_urls.yaml" });
 	debug("Done");
 }
 

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -9,7 +9,7 @@ const debug = require('debug')('github');
 const pullDataFiles = async () => {
 	debug("Pulling data files...");
 	await download("https://raw.githubusercontent.com/CryptoScamDB/whitelist/master/data/urls.yaml", "data", { filename: "whitelist_urls.yaml" });
-	await download("https://gist.githubusercontent.com/hahnmichaelf/43eb34ebbc88d9b7bf23748469f7bf8e/raw/urls.yaml", "data", { filename: "blacklist_urls.yaml" });
+	await download("https://raw.githubusercontent.com/CryptoScamDB/blacklist/master/data/urls.yaml", "data", { filename: "blacklist_urls.yaml" });
 	debug("Done");
 }
 

--- a/src/views/pages/config.ejs
+++ b/src/views/pages/config.ejs
@@ -212,9 +212,9 @@
 			input: '#cache-expiration-input'
 		});
 		$('#cache-renewal-range').range({
-			min: 1,
-			max: 60,
-			start: 5,
+			min: 15,
+			max: 120,
+			start: 60,
 			input: '#cache-renewal-input'
 		});
 		$('#database-persist-range').range({


### PR DESCRIPTION
-Adds support for category/subcategory updates on cache persist.
-Adds support for `coin` and `reportedby` fields in blacklist_urls.yaml.

I tested these using a gist found here: https://gist.githubusercontent.com/hahnmichaelf/43eb34ebbc88d9b7bf23748469f7bf8e/raw/urls.yaml

**Just now noticing that it has some funky spacing problems. Maybe because i use 4-space tabs.**